### PR TITLE
Constrain the 1.X branch to use Chef 10.x

### DIFF
--- a/knife-tar.gemspec
+++ b/knife-tar.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   # Removes gem build warning
   s.rubyforge_project = "nowarning"
   
-  s.add_dependency 'chef', '>= 0.10.0'
+  s.add_dependency 'chef', '~> 10.12'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
 end


### PR DESCRIPTION
I believe that the 1.X branch is for Chef 10.x and master is for Chef 11.x currently.  We ran into an issue where installing the 1.3.0 version of this gem will install Chef 11.x over a Chef 10.x install.  This pull request constrains to only Chef 10.x versions.
